### PR TITLE
Update lodash dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
lodash@<3.0.0 is no longer maintained.

All tests pass when using lodash 3.10.1